### PR TITLE
fix(besu): eliminate some false positive conditions in 0xdead detection

### DIFF
--- a/besu/src/test/java/com/blockchaintp/besu/daml/ZeroMarkingTest.java
+++ b/besu/src/test/java/com/blockchaintp/besu/daml/ZeroMarkingTest.java
@@ -44,10 +44,11 @@ public class ZeroMarkingTest {
     assertEquals(dataValue.toMinimalBytes(), unmarked);
   }
 
-  @Test(expected = NumberFormatException.class)
-  public void testSXT4XXShouldThrow() {
+  @Test
+  public void testSXT849ShouldNotThrow() {
     var dataValue = UInt256.fromHexString(SXT849_PROBLEM_SLOT0);
-    ZeroMarking.unmarkZeros(dataValue);
+    var testBytes = ZeroMarking.unmarkZeros(dataValue);
+    assertEquals(dataValue.toMinimalBytes(), testBytes);
   }
 
   @Test


### PR DESCRIPTION
Signed-off-by: Kevin O'Donnell <kevin@blockchaintp.com>
