### PR TITLE
Build Docker image using Azul Zulu image rather than package download

### DIFF
--- a/docker/besu.dockerfile
+++ b/docker/besu.dockerfile
@@ -26,7 +26,7 @@ WORKDIR /opt/daml-on-besu
 COPY besu/target /project
 RUN unzip -qq /project/*-bin.zip && mv besu* besu && rm -rf /project/*
 
-# -----
+# ------------------------------------------------------------------------------
 FROM azul/zulu-openjdk:11.0.15-11.56.19
 
 COPY --from=install /opt/besu /opt/besu

--- a/docker/besu.dockerfile
+++ b/docker/besu.dockerfile
@@ -15,23 +15,6 @@
 FROM hyperledger/besu:1.4.0 as install
 
 # ------------------------------------------------------------------------------
-FROM ubuntu:bionic as ubuntu-zulu-base
-
-RUN \
-  apt-get update -y && \
-  apt-get install -y \
-  curl \
-  gnupg \
-  software-properties-common \
-  wget
-
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-  apt-add-repository 'deb http://repos.azulsystems.com/ubuntu stable main' && \
-  apt-get update -y && \
-  apt-get install -y \
-  zulu-11
-
-# ------------------------------------------------------------------------------
 FROM ubuntu:bionic as build
 
 RUN \
@@ -44,7 +27,7 @@ COPY besu/target /project
 RUN unzip -qq /project/*-bin.zip && mv besu* besu && rm -rf /project/*
 
 # -----
-FROM ubuntu-zulu-base
+FROM azul/zulu-openjdk:11.0.15-11.56.19
 
 COPY --from=install /opt/besu /opt/besu
 COPY --from=build /opt/daml-on-besu /opt/daml-on-besu

--- a/docker/besu.dockerfile
+++ b/docker/besu.dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2020 Blockchain Technology Partners
+# Copyright 2020-2022 Blockchain Technology Partners
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docker/ledger-api-testtool.docker
+++ b/docker/ledger-api-testtool.docker
@@ -1,4 +1,4 @@
-# Copyright 2020 Blockchain Techology Partners
+# Copyright 2020-2022 Blockchain Technology Partners
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docker/ledger-api-testtool.docker
+++ b/docker/ledger-api-testtool.docker
@@ -11,37 +11,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ------------------------------------------------------------------------------
-FROM ubuntu:bionic as ubuntu-base
-
-RUN \
-  apt-get update -y && \
-  apt-get install -y \
-  curl \
-  gnupg \
-  software-properties-common \
-  wget
-
-# ------------------------------------------------------------------------------
-FROM ubuntu-base as ubuntu-zulu
-
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-  apt-add-repository 'deb http://repos.azulsystems.com/ubuntu stable main' && \
-  apt-get update -y && \
-  apt-get install -y \
-  zulu-11
-
-# ------------------------------------------------------------------------------
-FROM ubuntu-zulu
+FROM azul/zulu-openjdk:11.0.15-11.56.19
 
 ARG DAML_SDK_VERSION=1.13.1
 ARG DAML_REPO_VERSION=1.13.1
 
 RUN apt-get update -y && \
   apt-get install -y \
+  curl \
   groff \
   python3-pip \
-  tar
+  wget
 
 RUN curl -sSL https://get.daml.com/ | sh -s $DAML_SDK_VERSION && \
   mkdir -p /opt && \

--- a/docker/rpc.dockerfile
+++ b/docker/rpc.dockerfile
@@ -12,23 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ------------------------------------------------------------------------------
-FROM ubuntu:bionic as ubuntu-zulu-base
-
-RUN \
-  apt-get update -y && \
-  apt-get install -y \
-  curl \
-  gnupg \
-  software-properties-common \
-  wget
-
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-  apt-add-repository 'deb http://repos.azulsystems.com/ubuntu stable main' && \
-  apt-get update -y && \
-  apt-get install -y \
-  zulu-11
-
-# ------------------------------------------------------------------------------
 FROM ubuntu:bionic as build
 
 RUN \
@@ -41,7 +24,7 @@ COPY rpc/target  /project
 RUN unzip -qq /project/*-bin.zip && mv rpc* rpc && rm -rf /project/*
 
 # ------------------------------------------------------------------------------
-FROM ubuntu-zulu-base
+FROM azul/zulu-openjdk:11.0.15-11.56.19
 
 COPY --from=build /opt/daml-on-besu /opt/daml-on-besu
 

--- a/docker/rpc.dockerfile
+++ b/docker/rpc.dockerfile
@@ -20,7 +20,7 @@ RUN \
   zip
 
 WORKDIR /opt/daml-on-besu
-COPY rpc/target  /project
+COPY rpc/target /project
 RUN unzip -qq /project/*-bin.zip && mv rpc* rpc && rm -rf /project/*
 
 # ------------------------------------------------------------------------------

--- a/docker/rpc.dockerfile
+++ b/docker/rpc.dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2020 Blockchain Technology Partners
+# Copyright 2020-2022 Blockchain Technology Partners
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Explores simplifying the Docker files by basing the Ubuntu build on an image that already contains OpenJDK.

`azul/zulu-openjdk:11.0.15-11.56.19` is chosen to match `java zulu-11.56.19` from `.tool-versions`.